### PR TITLE
(PHP 7.1 compat) Change required arg, set default

### DIFF
--- a/taxonomy-images.php
+++ b/taxonomy-images.php
@@ -420,7 +420,7 @@ function taxonomy_image_plugin_control_taxonomies() {
  *
  * @access    private
  */
-function taxonomy_image_plugin_json_response( $args ) {
+function taxonomy_image_plugin_json_response( $args = array() ) {
 	/* translators: An ajax request has failed for an unknown reason. */
 	$response = wp_parse_args( $args, array(
 		'status' => 'bad',


### PR DESCRIPTION
In PHP 7.1, not passing enough arguments will cause a fatal error. http://php.net/manual/en/migration71.incompatible.php#migration71.incompatible.too-few-arguments-exception

`taxonomy_image_plugin_json_response()` is called twice with zero arguments (lines 574, 647), but the function definition requires 1. Patch removes the requirement and sets a default.